### PR TITLE
JS/CSS file enqueues now works with secure admin

### DIFF
--- a/cms-page-order.php
+++ b/cms-page-order.php
@@ -36,7 +36,7 @@ License: Public Domain
 */
 
 define( 'CMSPO_VERSION', '0.3.3' );
-define( 'CMSPO_URL', WP_PLUGIN_URL . '/cms-page-order/' );
+define( 'CMSPO_URL', plugin_dir_url( __FILE__ ) );
 
 add_action( 'wp_ajax_save_tree', 'cmspo_ajax_save_tree' );
 add_action( 'wp_ajax_remove_label', 'cmspo_ajax_remove_label' );

--- a/cms-page-order.php
+++ b/cms-page-order.php
@@ -354,15 +354,15 @@ function cmspo_do_err() {
 
 /** Special Walker for the Pages */
 class PO_Walker extends Walker_Page {
-	function start_lvl(&$output, $depth) {
+	function start_lvl(&$output, $depth = 0, $args = array()) {
 		$indent = str_repeat("\t", $depth);
 		$output .= "\n$indent<ol class=\"cmspo-children\">\n";
 	}
-	function end_lvl(&$output, $depth) {
+	function end_lvl(&$output, $depth = 0, $args = array()) {
 		$indent = str_repeat("\t", $depth);
 		$output .= "$indent</ol>\n";
 	}
-	function start_el(&$output, $page, $depth, $args) {
+	function start_el(&$output, $page, $depth = 0, $args = array(), $current_page = 0) {
 		if ( $depth )
 			$indent = str_repeat("\t", $depth);
 		else


### PR DESCRIPTION
Hey Bill, thanks for the excellent plugin. In the current version of CMS Page Order, the script/style enqueues fails when the WordPress admin is running under SSL. This is because the WP_PLUGIN_URL constant doesn't support HTTPS (see http://codex.wordpress.org/Determining_Plugin_and_Content_Directories).

I've updated the CMSPO_URL to use plugin_dir_url() instead of WP_PLUGIN_URL.

Thanks again for this awesome plugin!
