### PR TITLE
Match PO_Walker method args to Walker_Page method args.

### DIFF
--- a/cms-page-order.php
+++ b/cms-page-order.php
@@ -354,15 +354,15 @@ function cmspo_do_err() {
 
 /** Special Walker for the Pages */
 class PO_Walker extends Walker_Page {
-	function start_lvl(&$output, $depth) {
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent = str_repeat("\t", $depth);
 		$output .= "\n$indent<ol class=\"cmspo-children\">\n";
 	}
-	function end_lvl(&$output, $depth) {
+	function end_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent = str_repeat("\t", $depth);
 		$output .= "$indent</ol>\n";
 	}
-	function start_el(&$output, $page, $depth, $args) {
+	function start_el( &$output, $page, $depth = 0, $args = array(), $current_page = 0 ) {
 		if ( $depth )
 			$indent = str_repeat("\t", $depth);
 		else


### PR DESCRIPTION
Extra arguments were added in WordPress 3.4 for start_lvl(), end_lvl() and start_el()

Just noticed as I was debugging something else.
